### PR TITLE
Add gridlines to board

### DIFF
--- a/bin/main.ml
+++ b/bin/main.ml
@@ -9,11 +9,10 @@
 
 open Lwt
 open LTerm_geom
-
-(* open LTerm_text *)
 open LTerm_key
 open Koiiword.Board
 open Koiiword.State
+open CamomileLibrary
 
 (** The [loop_result] type describes the response of the gameplay loop
     to an event. Currently, the game can respond by doing nothing
@@ -47,6 +46,11 @@ let rec loop (ui : LTerm_ui.t) (game_state : game_state ref) :
         LoopResultUpdateState
           { board = { cursor = (fst cursor, snd cursor + 1) } }
     | LTerm_event.Key { code = Escape; _ } -> LoopResultExit
+    | LTerm_event.Key { code = LTerm_key.Char c; control = true; _ }
+      -> (
+        match UChar.char_of c with
+        | 'c' -> LoopResultExit
+        | _ -> LoopResultContinue)
     | _ -> LoopResultContinue
   in
   match loop_result with
@@ -57,18 +61,41 @@ let rec loop (ui : LTerm_ui.t) (game_state : game_state ref) :
       loop ui game_state
   | LoopResultContinue -> loop ui game_state
 
+let draw_grid ctx rect =
+  let rec range start stop step fn =
+    fn start;
+    if start + step < stop then range (start + step) stop step fn
+  in
+  let width = rect.col2 - rect.col1 in
+  let height = rect.row2 - rect.row1 in
+  let spacing = 2 in
+  let style =
+    { LTerm_style.none with foreground = Some LTerm_style.green }
+  in
+
+  (* draw hlines *)
+  range rect.row1 rect.row2 spacing (fun row ->
+      LTerm_draw.draw_hline ctx (rect.row1 + row) rect.col1 width ~style
+        LTerm_draw.Light);
+
+  (* draw vlines *)
+  range rect.col1 rect.col2 spacing (fun col ->
+      LTerm_draw.draw_vline ctx rect.row1 (rect.col1 + col) height
+        ~style LTerm_draw.Light)
+
 (** The renderer. This takes game state and a terminal UI object and
     renders the game according to its current state. *)
 let draw ui_terminal matrix (game_state : game_state) =
   let size = LTerm_ui.size ui_terminal in
   let ctx = LTerm_draw.context matrix size in
   LTerm_draw.clear ctx;
-  LTerm_draw.draw_frame_labelled ctx
-    { row1 = 0; col1 = 0; row2 = size.rows; col2 = size.cols }
-    ~alignment:H_align_center
-    (Zed_string.of_utf8 "koiiword")
-    LTerm_draw.Light;
-  if size.rows > 2 && size.cols > 2 then
+  LTerm_draw.draw_hline ctx 0 0 size.cols LTerm_draw.Heavy;
+  LTerm_draw.draw_string_aligned ctx 0 H_align_center
+    (Zed_string.of_utf8 " koiiword ");
+  LTerm_draw.draw_frame ctx
+    { row1 = 1; col1 = 1; row2 = size.rows - 1; col2 = size.cols - 1 }
+    LTerm_draw.Heavy;
+  if size.rows > 2 && size.cols > 2 then (
     let ctx =
       LTerm_draw.sub ctx
         {
@@ -78,9 +105,15 @@ let draw ui_terminal matrix (game_state : game_state) =
           col2 = size.cols - 1;
         }
     in
+    let size = LTerm_draw.size ctx in
+    draw_grid ctx
+      { row1 = 1; col1 = 1; row2 = size.rows - 1; col2 = size.cols - 1 };
     let row, col = game_state.board.cursor in
     let style = { LTerm_style.none with reverse = Some true } in
-    LTerm_draw.draw_char ctx row col ~style (Zed_char.of_utf8 "*")
+    LTerm_draw.draw_char ctx
+      ((row * 2) + 1)
+      ((col * 2) + 1)
+      ~style (Zed_char.of_utf8 "*"))
 
 let main () =
   let%lwt term = Lazy.force LTerm.stdout in


### PR DESCRIPTION
- Board now displays with grid lines, and cursor is snapped so that it appears inside of the grid cells
- Game now exits on Ctrl-C