### PR TITLE
Restructure unit tests

### DIFF
--- a/lib/util.ml
+++ b/lib/util.ml
@@ -1,0 +1,16 @@
+(** [slice lst n] will return two lists [(left, right)], where [left]
+    contains items 0 until [n] from [lst] and [right] contains all
+    remaining items. *)
+let slice (lst : 'a list) (n : int) : 'a list * 'a list =
+  let rec slice_inner
+      (lst_a : 'a list)
+      (lst_b : 'a list)
+      (n : int)
+      (i : int) : 'a list * 'a list =
+    if n = i then (lst_a, lst_b)
+    else
+      match lst_b with
+      | [] -> (lst_a, [])
+      | h :: t -> slice_inner (lst_a @ [ h ]) t n (i + 1)
+  in
+  slice_inner [] lst n 0

--- a/test/dune
+++ b/test/dune
@@ -1,3 +1,6 @@
 (executable
  (name main)
  (libraries lwt ounit2 koiiword))
+(rule
+ (alias  runtest)
+ (action (run ./main.exe)))

--- a/test/generate_letters_test.ml
+++ b/test/generate_letters_test.ml
@@ -1,0 +1,32 @@
+open OUnit2
+open Koiiword
+
+let rec all_letters = function
+  | [] -> true
+  | h :: t -> (
+      try Char.code h > 64 && Char.code h < 91 && all_letters t
+      with Invalid_argument _ -> false)
+
+let start_game_testlength (name : string) (deck : char list) : test =
+  name >:: fun _ -> assert_equal true (List.length deck = 7)
+
+let start_game_testcontent (name : string) (deck : char list) : test =
+  name >:: fun _ -> assert_equal true (all_letters deck)
+
+let temp_deck = Generate_letters.start_game []
+
+let test_cases =
+  [
+    (* test start_game*)
+    start_game_testlength "start game creates list of length 7"
+      temp_deck;
+    start_game_testcontent "start game creates list of letters A-Z"
+      temp_deck;
+    (* test remove_let*)
+    start_game_testlength "start game creates list of length 7"
+      (Generate_letters.remove_let 0 2 temp_deck);
+    start_game_testcontent "start game creates list of letters A-Z"
+      (Generate_letters.remove_let 0 2 temp_deck);
+  ]
+
+let suite = "test suite for Generate_letters" >::: test_cases

--- a/test/main.ml
+++ b/test/main.ml
@@ -1,35 +1,6 @@
 open OUnit2
-open Koiiword
 
-let rec all_letters = function
-  | [] -> true
-  | h :: t -> (
-      try Char.code h > 64 && Char.code h < 91 && all_letters t
-      with Invalid_argument _ -> false)
+let super_suite = 
+  test_list [Generate_letters_test.suite; Util_test.suite]
 
-let start_game_testlength (name : string) (deck : char list) : test =
-  name >:: fun _ -> assert_equal true (List.length deck = 7)
-
-let start_game_testcontent (name : string) (deck : char list) : test =
-  name >:: fun _ -> assert_equal true (all_letters deck)
-
-let temp_deck = Generate_letters.start_game []
-
-let test_cases =
-  [
-    (* test start_game*)
-    start_game_testlength "start game creates list of length 7"
-      temp_deck;
-    start_game_testcontent "start game creates list of letters A-Z"
-      temp_deck;
-    (* test remove_let*)
-    start_game_testlength "start game creates list of length 7"
-      (Generate_letters.remove_let 0 2 temp_deck);
-    start_game_testcontent "start game creates list of letters A-Z"
-      (Generate_letters.remove_let 0 2 temp_deck);
-  ]
-
-let suite =
-  "test suite for generateLetters" >::: List.flatten [ test_cases ]
-
-let _ = run_test_tt_main suite
+let _ = run_test_tt_main super_suite

--- a/test/util.ml
+++ b/test/util.ml
@@ -1,0 +1,1 @@
+let pp_list pp_item lst = "[" ^ (String.concat ", " (List.map pp_item lst)) ^ "]"

--- a/test/util_test.ml
+++ b/test/util_test.ml
@@ -1,0 +1,31 @@
+open OUnit2
+open Koiiword.Util
+open Util
+
+let slice_test (lst : int list) n (expected_left, expected_right) : test
+    =
+  let test_name =
+    Printf.sprintf "slice %s %d gives (%s, %s)"
+      (pp_list string_of_int lst)
+      n
+      (pp_list string_of_int expected_left)
+      (pp_list string_of_int expected_right)
+  in
+  test_name >:: fun _ ->
+  assert_equal (expected_left, expected_right) (slice lst n)
+    ~printer:(fun (left, right) ->
+      Printf.sprintf "(%s, %s)"
+        (pp_list string_of_int left)
+        (pp_list string_of_int right))
+
+let slice_tests =
+  "test suite for Util.slice"
+  >::: [
+         slice_test [ 0; 1; 2; 3 ] 2 ([ 0; 1 ], [ 2; 3 ]);
+         slice_test [ 0; 1; 2; 3 ] 4 ([ 0; 1; 2; 3 ], []);
+         slice_test [ 0; 1; 2; 3 ] 6 ([ 0; 1; 2; 3 ], []);
+         slice_test [ 0; 1; 2; 3 ] 1 ([ 0 ], [ 1; 2; 3 ]);
+       ]
+
+let suite =
+  "test suite for Koiiword.Util functions" >::: [ slice_tests ]


### PR DESCRIPTION
- Added a `Util` module containing a `slice` function which I was going to use in a later PR
- Created a unit test module for every module that is being tested; `main.ml` no longer contains any unit test definitions, instead it imports and combines the test suites from all of the unit test modules