### PR TITLE
Create grid layout system

### DIFF
--- a/lib/layout.ml
+++ b/lib/layout.ml
@@ -1,0 +1,46 @@
+open LTerm_geom
+
+type grid_layout_spec = {
+  rows : float list;
+  cols : float list;
+}
+
+let get_grid_rect
+    (bounds : rect)
+    (layout_spec : grid_layout_spec)
+    (row_start : int)
+    (row_span : int)
+    (col_start : int)
+    (col_span : int) : LTerm_geom.rect =
+  let col_start = col_start - 1 in
+  let row_start = row_start - 1 in
+  let start_col_breakpoint =
+    if col_start < 0 then 0. else List.nth layout_spec.cols col_start
+  in
+  let end_col_breakpoint =
+    if col_start + col_span >= List.length layout_spec.cols then 1.
+    else List.nth layout_spec.cols (col_start + col_span)
+  in
+  let start_row_breakpoint =
+    if row_start < 0 then 0. else List.nth layout_spec.rows row_start
+  in
+  let end_row_breakpoint =
+    if row_start + row_span >= List.length layout_spec.rows then 1.
+    else List.nth layout_spec.rows (row_start + row_span)
+  in
+  let bounds_width = float_of_int (bounds.col2 - bounds.col1) in
+  let bounds_height = float_of_int (bounds.row2 - bounds.row1) in
+  {
+    row1 = bounds.row1 + int_of_float (start_row_breakpoint *. bounds_height);
+    row2 = bounds.row1 + int_of_float (end_row_breakpoint *. bounds_height);
+    col1 = bounds.col1 + int_of_float (start_col_breakpoint *. bounds_width);
+    col2 = bounds.col1 + int_of_float (end_col_breakpoint *. bounds_width);
+  }
+
+let inset rect x: rect =
+  {
+    row1 = rect.row1 + x;
+    row2 = rect.row2 - x;
+    col1 = rect.col1 + x;
+    col2 = rect.col2 - x;
+  }

--- a/lib/layout.ml
+++ b/lib/layout.ml
@@ -1,10 +1,18 @@
 open LTerm_geom
 
+(* A grid layout spec is a list of all of the dividing lines in a
+   grid-based layout. each dividing line is represented as a float,
+   which is the fraction of the width / height that this dividing line
+   is placed from the left / top. *)
 type grid_layout_spec = {
   rows : float list;
   cols : float list;
 }
 
+(* [get_grid_rect] will return the rectangle that a given grid cell or
+   group of grid cells (as specified by [row_start row_span col_start
+   col_span]) would occupy given that the entire grid occupies the
+   rectangle specified by [bounds]. *)
 let get_grid_rect
     (bounds : rect)
     (layout_spec : grid_layout_spec)
@@ -31,13 +39,19 @@ let get_grid_rect
   let bounds_width = float_of_int (bounds.col2 - bounds.col1) in
   let bounds_height = float_of_int (bounds.row2 - bounds.row1) in
   {
-    row1 = bounds.row1 + int_of_float (start_row_breakpoint *. bounds_height);
-    row2 = bounds.row1 + int_of_float (end_row_breakpoint *. bounds_height);
-    col1 = bounds.col1 + int_of_float (start_col_breakpoint *. bounds_width);
-    col2 = bounds.col1 + int_of_float (end_col_breakpoint *. bounds_width);
+    row1 =
+      bounds.row1 + int_of_float (start_row_breakpoint *. bounds_height);
+    row2 =
+      bounds.row1 + int_of_float (end_row_breakpoint *. bounds_height);
+    col1 =
+      bounds.col1 + int_of_float (start_col_breakpoint *. bounds_width);
+    col2 =
+      bounds.col1 + int_of_float (end_col_breakpoint *. bounds_width);
   }
 
-let inset rect x: rect =
+(* [inset rect x] returns a new rectangle where each edge has been moved
+   inwards by [x] units. *)
+let inset rect x : rect =
   {
     row1 = rect.row1 + x;
     row2 = rect.row2 - x;

--- a/test/layout_test.ml
+++ b/test/layout_test.ml
@@ -1,0 +1,64 @@
+open OUnit2
+open Koiiword.Layout
+open Util
+
+let pp_rect (rect : LTerm_geom.rect) : string =
+  Printf.sprintf "<rect pos = (%d, %d), size = (%d, %d)>" rect.col1
+    rect.row1 (rect.col2 - rect.col1) (rect.row2 - rect.row1)
+
+let get_grid_rect_test
+    bounds
+    layout_spec
+    row_start
+    row_span
+    col_start
+    col_span
+    expected : test =
+  let test_name =
+    Printf.sprintf
+      "get_grid_rect %s { cols = %s, rows = %s } %d %d %d %d gives %s"
+      (pp_rect bounds)
+      (pp_list string_of_float layout_spec.cols)
+      (pp_list string_of_float layout_spec.rows)
+      row_start row_span col_start col_span (pp_rect expected)
+  in
+  test_name >:: fun _ ->
+  assert_equal expected
+    (get_grid_rect bounds layout_spec row_start row_span col_start
+       col_span)
+    ~printer:pp_rect
+
+let bounds : LTerm_geom.rect =
+  { row1 = 0; row2 = 100; col1 = 0; col2 = 100 }
+
+let bounds2 : LTerm_geom.rect =
+  { row1 = 10; row2 = 110; col1 = 10; col2 = 110 }
+
+let layout_spec = { rows = [ 0.3; 0.7 ]; cols = [ 0.2; 0.8 ] }
+
+let get_grid_rect_tests =
+  "test suite for Layout.get_grid_rect"
+  >::: [
+         get_grid_rect_test bounds layout_spec 0 1 0 1
+           { row1 = 0; row2 = 30; col1 = 0; col2 = 20 };
+         get_grid_rect_test bounds layout_spec 1 1 0 1
+           { row1 = 30; row2 = 70; col1 = 0; col2 = 20 };
+         get_grid_rect_test bounds layout_spec 0 2 0 1
+           { row1 = 0; row2 = 70; col1 = 0; col2 = 20 };
+         get_grid_rect_test bounds layout_spec 0 3 0 1
+           { row1 = 0; row2 = 100; col1 = 0; col2 = 20 };
+         get_grid_rect_test bounds layout_spec 0 4 0 1
+           { row1 = 0; row2 = 100; col1 = 0; col2 = 20 };
+         get_grid_rect_test bounds layout_spec 0 1 0 3
+           { row1 = 0; row2 = 30; col1 = 0; col2 = 100 };
+         get_grid_rect_test bounds layout_spec 0 3 0 3
+           { row1 = 0; row2 = 100; col1 = 0; col2 = 100 };
+         get_grid_rect_test bounds layout_spec 1 1 1 1
+           { row1 = 30; row2 = 70; col1 = 20; col2 = 80 };
+         get_grid_rect_test bounds2 layout_spec 1 1 1 1
+           { row1 = 40; row2 = 80; col1 = 30; col2 = 90 };
+       ]
+
+let suite =
+  "test suite for Koiiword.Layout functions"
+  >::: [ get_grid_rect_tests ]

--- a/test/main.ml
+++ b/test/main.ml
@@ -1,6 +1,7 @@
 open OUnit2
 
-let super_suite = 
-  test_list [Generate_letters_test.suite; Util_test.suite]
+let super_suite =
+  test_list
+    [ Generate_letters_test.suite; Util_test.suite; Layout_test.suite ]
 
 let _ = run_test_tt_main super_suite


### PR DESCRIPTION
- Create `get_grid_rect`, which is used in #17 to get the bounding rectangle of a grid cell given a layout specification