### PR TITLE
delete license statement at the top of main.ml

### DIFF
--- a/bin/main.ml
+++ b/bin/main.ml
@@ -1,12 +1,3 @@
-(*
- * move.ml
- * -------
- * Copyright : (c) 2011, Jeremie Dimino <jeremie@dimino.org>
- * Licence   : BSD3
- *
- * This file is a part of Lambda-Term.
- *)
-
 open Lwt
 open LTerm_geom
 


### PR DESCRIPTION
this file is no longer the demo file from Lambda-Term, so the license is deleted