### PR TITLE
Add victory screen

### DIFF
--- a/bin/main.ml
+++ b/bin/main.ml
@@ -447,6 +447,7 @@ let draw_board_tiles ctx pan tiles =
     (fun (position, letter) ->
       let row, col = get_tile_screen_position ctx pan position in
       LTerm_draw.draw_char ctx (row + 1) (col + 1)
+        ~style:{ LTerm_style.none with bold = Some true }
         (Zed_char.of_utf8 (String.make 1 letter));
       LTerm_draw.draw_char ctx (row + 1) (col + 2)
         (Zed_char.of_utf8 " "))

--- a/lib/dictionary.ml
+++ b/lib/dictionary.ml
@@ -9,7 +9,9 @@ let dict_from_file (file_name : string) : dictionary =
   let ht = Hashtbl.create 400000 in
   try
     while true do
-      let line = String.uppercase_ascii (String.trim (input_line ic)) in
+      let line =
+        input_line ic |> String.trim |> String.uppercase_ascii
+      in
       Hashtbl.add ht line ()
     done;
     ht
@@ -22,4 +24,3 @@ let dict_from_file (file_name : string) : dictionary =
     otherwise *)
 let is_word_valid (dict : dictionary) (word : string) =
   Hashtbl.mem dict (String.uppercase_ascii word)
-

--- a/lib/state.ml
+++ b/lib/state.ml
@@ -13,7 +13,19 @@ type gameplay_state = {
   dict : dictionary;
 }
 
+type victory_state = { winner : player }
+
 type game_state =
   | Title
   | Gameplay of gameplay_state
-  | Victory of player
+  | Victory of victory_state
+
+let blank_gameplay_state player_lst dictionary =
+  {
+    board = new_board ();
+    players =  player_lst;
+    entry = SelectStart;
+    instructions = Instructions.StartGame;
+    current_player_index = 0;
+    dict = dictionary;
+  }

--- a/test/dictionary_test.ml
+++ b/test/dictionary_test.ml
@@ -6,9 +6,8 @@ let test_length
     (file_name : string)
     (expected_output : int) : test =
   name >:: fun _ ->
-  assert_equal
-    (Hashtbl.length (dict_from_file file_name))
-    expected_output
+  let dict = dict_from_file file_name in
+  assert_equal (Hashtbl.length dict) expected_output
 
 let test_word_valid
     (name : string)
@@ -16,10 +15,9 @@ let test_word_valid
     (input_words : string list)
     (expected_output : bool) : test =
   name >:: fun _ ->
+  let dict = dict_from_file file_name in
   assert_equal
-    (List.for_all
-       (is_word_valid (dict_from_file file_name))
-       input_words)
+    (List.for_all (is_word_valid dict) input_words)
     expected_output
 
 let test_cases =


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/14832331/145744050-ef8f5195-2059-4ad0-a9c9-8deae3d8414c.png)
![image](https://user-images.githubusercontent.com/14832331/145744172-af5a7f90-67d2-4f6a-b622-fed1526d7a04.png)


- Game now properly transitions into `Victory` state when a player hits the point limit (for now it is 10 points)
- Player can press any key in order to restart into a new game
- Tiles placed on the board by the player now feature bold letters, making them easier to distinguish from the tile multipliers